### PR TITLE
Fix for "Ambiguous occurrence ‘role’"

### DIFF
--- a/src/Text/Digestive/Bootstrap.hs
+++ b/src/Text/Digestive/Bootstrap.hs
@@ -13,7 +13,7 @@ import Data.Monoid
 import Network.HTTP.Types.Method
 import Text.Blaze.Bootstrap
 import Text.Blaze.Html5
-import Text.Blaze.Html5.Attributes
+import Text.Blaze.Html5.Attributes hiding (role)
 import Text.Digestive
 import Text.Digestive.Blaze.Html5
 import qualified Data.Text as T


### PR DESCRIPTION
The funblog Spock example fails to compile due to:

```
[1 of 1] Compiling Text.Digestive.Bootstrap ( src/Text/Digestive/Bootstrap.hs, dist/build/Text/Digestive/Bootstrap.o, dist/build/Text/Digestive/Bootstrap.dyn_o )

src/Text/Digestive/Bootstrap.hs:72:14: error:
    Ambiguous occurrence ‘role’
    It could refer to
       either ‘Text.Blaze.Bootstrap.role’,
              imported from ‘Text.Blaze.Bootstrap’ at src/Text/Digestive/Bootstrap.hs:14:1-27
           or ‘Text.Blaze.Html5.Attributes.role’,
              imported from ‘Text.Blaze.Html5.Attributes’ at src/Text/Digestive/Bootstrap.hs:16:1-34
   |
72 |     H.form ! role "form" ! method formMethod ! action formAction $
   |              ^^^^
cabal: Failed to build digestive-bootstrap-0.3.0.0 (which is required by
exe:funblog from funblog-0.4.1.0). See the build log above for details.
```

I've guessed that 'role' is intended to mean the role in ‘Text.Blaze.Bootstrap’ since it's part of a "agrafix" package